### PR TITLE
[Issue#7] Fix filter preview label

### DIFF
--- a/view/adminhtml/web/js/form/element/select2.js
+++ b/view/adminhtml/web/js/form/element/select2.js
@@ -53,6 +53,10 @@ define([
 
             }
 
+            if (options.initialValue) {
+                $element.select2().val(options.initialValue).trigger('change');
+            }
+
             $element.select2(options);
 
             $element.on("select2:select", function (e) {
@@ -76,6 +80,19 @@ define([
             this._super();
 
             this.observe('select2');
+
+            return this;
+        },
+
+        /** @inheritdoc */
+        setInitialValue: function () {
+            var value = this.getInitialValue();
+
+            if (!_.isString(value)) {
+                this._super();
+            }
+
+            this.select2().initialValue = value;
 
             return this;
         },


### PR DESCRIPTION
Possible fix for #7 

#Steps to reproduce
- While maximumSelectionLength is 1
- Data population when the select2 is loaded as the preview cannot be shown as default selected option.

#Expected result
- maximumSelectionLength set as 1 then preview could be loaded as selected option.